### PR TITLE
runbook and parse code updates

### DIFF
--- a/codebundles/aws-c7n-ec2-health/.test/README.md
+++ b/codebundles/aws-c7n-ec2-health/.test/README.md
@@ -110,3 +110,9 @@ To test an Invalid Auto Scaling Group (ASG) task, manually delete EC2 Key Pair.
 	```
 	aws ec2 delete-key-pair --key-name my-ec2-key --region us-west-2
 	```
+or a Laumnch Template
+
+	```
+	template_id=$(cd terraform && terraform show -json terraform.tfstate | jq -r  '.values.root_module.resources[] | select(.type == "aws_autoscaling_group") | .values.launch_template[0].id')
+	aws ec2 delete-launch-template --launch-template-id $template_id --region us-west-2
+	```

--- a/codebundles/aws-c7n-ec2-health/.test/terraform/ec2.tf
+++ b/codebundles/aws-c7n-ec2-health/.test/terraform/ec2.tf
@@ -214,3 +214,7 @@ output "private_key" {
 output "public_key" {
   value = tls_private_key.ssh_key.public_key_openssh
 }
+
+output "launch_template" {
+  value = aws_autoscaling_group.example.launch_configuration
+}

--- a/codebundles/aws-c7n-ec2-health/runbook.robot
+++ b/codebundles/aws-c7n-ec2-health/runbook.robot
@@ -156,10 +156,9 @@ List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account 
         FOR    ${asg}    IN    @{asg_list}
             ${asg_name}=    Set Variable    ${asg["AutoScalingGroupName"]}
             ${invalid_items}=    Evaluate    ${asg}.get("Invalid", [])
-            IF    $invalid_items
-                Log    "True"
+            IF    ${invalid_items} == True
                 RW.Core.Add Issue
-                ...    severity=3
+                ...    severity=2
                 ...    actual=Auto Scaling Group ${asg_name} in AWS Region ${AWS_REGION} in AWS Account ${AWS_ACCOUNT_ID} is invalid
                 ...    expected=Auto Scaling Group ${asg_name} should be valid in AWS Region ${AWS_REGION} in AWS Account ${AWS_ACCOUNT_ID}
                 ...    title=Invalid Auto Scaling Group configuration for \`${asg_name}\` in AWS Region \`${AWS_REGION}\` in AWS Account \`${AWS_ACCOUNT_ID}\`
@@ -174,13 +173,13 @@ List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account 
                         ${human_friendly_key}=    Evaluate    '${invalid_key}'.replace("-", " ")
                         ${invalid_value}=    Set Variable    ${invalid_entry[1]}
                         RW.Core.Add Issue
-                        ...    severity=3
+                        ...    severity=2
                         ...    actual=Auto Scaling Group ${asg_name} in AWS Region ${AWS_REGION} in AWS Account ${AWS_ACCOUNT_ID} has ${human_friendly_key}
                         ...    expected=Auto Scaling Group ${asg_name} should not have ${human_friendly_key} in AWS Region ${AWS_REGION} in AWS Account ${AWS_ACCOUNT_ID}
-                        ...    title=Invalid `\${human_friendly_key}\` Auto Scaling Group configuration for \`${asg_name}\` in AWS Region \`${AWS_REGION}\` in AWS Account \`${AWS_ACCOUNT_ID}\`
+                        ...    title=Found ${human_friendly_key} in Auto Scaling Group \`${asg_name}\` in AWS Region \`${AWS_REGION}\` in AWS Account \`${AWS_ACCOUNT_ID}\`
                         ...    reproduce_hint=${c7n_output.cmd}
-                        ...    details=Auto Scaling Group: ${asg_name}\n${human_friendly_key}: ${invalid_value}
-                        ...    next_steps=Escalate invalid Auto Scaling Group \`${asg_name}\` configuration in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\` to service owner
+                        ...    details=Auto Scaling Group: ${asg_name}\n- ${human_friendly_key}: ${invalid_value}
+                        ...    next_steps=Fix ${human_friendly_key} Auto Scaling Group \`${asg_name}\` configuration in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\` to service owner
                     END
                 ELSE
                     RW.Core.Add Pre To Report    No invalid configurations found for ${asg_name}.

--- a/codebundles/aws-c7n-ec2-health/runbook.robot
+++ b/codebundles/aws-c7n-ec2-health/runbook.robot
@@ -179,7 +179,7 @@ List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account 
                         ...    title=Found ${human_friendly_key} in Auto Scaling Group \`${asg_name}\` in AWS Region \`${AWS_REGION}\` in AWS Account \`${AWS_ACCOUNT_ID}\`
                         ...    reproduce_hint=${c7n_output.cmd}
                         ...    details=Auto Scaling Group: ${asg_name}\n- ${human_friendly_key}: ${invalid_value}
-                        ...    next_steps=Fix ${human_friendly_key} Auto Scaling Group \`${asg_name}\` configuration in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\` to service owner
+                        ...    next_steps=Fix ${human_friendly_key} in Auto Scaling Group \`${asg_name}\` configuration in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\` to service owner
                     END
                 ELSE
                     RW.Core.Add Pre To Report    No invalid configurations found for ${asg_name}.

--- a/codebundles/aws-c7n-ec2-health/runbook.robot
+++ b/codebundles/aws-c7n-ec2-health/runbook.robot
@@ -31,7 +31,10 @@ List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS
 
     # Read the generated report data
     ${report_data}=     RW.CLI.Run Cli
-    ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ec2-health/stale-ec2-instances/resources.json 
+    ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ec2-health/stale-ec2-instances/resources.json
+    ${parsed_results}=    CloudCustodian.Core.Parse Custodian Results
+    ...    input_dir=${OUTPUT_DIR}/aws-c7n-ec2-health/stale-ec2-instances
+    RW.Core.Add Pre To Report    ${parsed_results} 
 
     TRY
         ${ec2_instances_list}=    Evaluate    json.loads(r'''${report_data.stdout}''')    json
@@ -40,7 +43,8 @@ List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS
         ${ec2_instances_list}=    Create List
     END
 
-    IF    len(@{ec2_instances_list}) > int(${MAX_ALLOWED_STALE_INSTANCES})
+    ${ec2_instances_list_length}    Evaluate    len(@{ec2_instances_list})
+    IF    ${ec2_instances_list_length} > int(${MAX_ALLOWED_STALE_INSTANCES})
         # Generate and format report 
         ${formatted_results}=    RW.CLI.Run Cli
         ...    cmd=jq -r --arg region "${AWS_REGION}" '["InstanceId", "InstanceType", "ImageId", "REGION", "Tags"], (.[] | [ .InstanceId, .InstanceType, .ImageId, $region, (.Tags | map(.Key + "=" + .Value) | join(","))]) | @tsv' ${OUTPUT_DIR}/aws-c7n-ec2-health/stale-ec2-instances/resources.json | column -t | awk '\''{if (NR == 1) print "Resource Summary:\\n" $0; else print $0}'\''
@@ -58,6 +62,8 @@ List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS
             ...    details=${pretty_item}
             ...    next_steps=Patch and restart EC2 instances in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\`\nDelete stale AWS EC2 instance in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\`
         END
+    ELSE
+        RW.Core.Add Pre To Report     ${ec2_instances_list_length} stale instances found, below threshold of ${MAX_ALLOWED_STALE_INSTANCES}\n${report_data.stdout}
     END
 
 List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
@@ -75,6 +81,10 @@ List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${A
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ec2-health ${CURDIR}/stopped-ec2-instances.yaml --cache-period 0
     ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
     ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+
+    ${parsed_results}=    CloudCustodian.Core.Parse Custodian Results
+    ...    input_dir=${OUTPUT_DIR}/aws-c7n-ec2-health/stopped-ec2-instances
+    RW.Core.Add Pre To Report    ${parsed_results} 
 
     # Read the generated report data
     ${report_data}=     RW.CLI.Run Cli
@@ -105,6 +115,8 @@ List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${A
             ...    details=${pretty_item}
             ...    next_steps=Delete stopped AWS EC2 instance in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\`
         END
+    ELSE
+        RW.Core.Add Pre To Report    len(@{ec2_instances_list}) stopped instances found, below threshold of ${MAX_ALLOWED_STOPPED_INSTANCES}\n${report_data.stdout}
     END
 
 List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account ${AWS_ACCOUNT_ID}
@@ -121,13 +133,18 @@ List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ec2-health/invalid-asg/resources.json 
 
+    ${parsed_results}=    CloudCustodian.Core.Parse Custodian Results
+    ...    input_dir=${OUTPUT_DIR}/aws-c7n-ec2-health/invalid-asg
+    RW.Core.Add Pre To Report    ${parsed_results} 
+
     TRY
         ${asg_list}=    Evaluate    json.loads(r'''${report_data.stdout}''')    json
     EXCEPT
         Log    Failed to load JSON payload, defaulting to empty list.    WARN
         ${asg_list}=    Create List
     END
-    IF    len(@{asg_list}) > int(${MAX_ALLOWED_INVALID_ASG})
+    ${asg_list_length}    Evaluate    len(@{asg_list})
+    IF    ${asg_list_length} > int(${MAX_ALLOWED_INVALID_ASG})
         # Generate and format report 
         ${formatted_results}=    RW.CLI.Run Cli
         ...    cmd=jq -r --arg region "${AWS_REGION}" '["AutoScalingGroupName", "LaunchConfigurationName", "MinSize", "MaxSize", "DesiredCapacity", "REGION", "Tags"], (.[] | [ .AutoScalingGroupName, .LaunchConfigurationName, .MinSize, .MaxSize, .DesiredCapacity, $region, (.Tags | map(.Key + "=" + .Value) | join(","))]) | @tsv' ${OUTPUT_DIR}/aws-c7n-ec2-health/invalid-asg/resources.json | column -t | awk '\''{if (NR == 1) print "Resource Summary:\\n" $0; else print $0}'\''
@@ -150,12 +167,14 @@ List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account 
                     ...    title=Invalid Auto Scaling Group found ${asg_name} in AWS Region ${AWS_REGION} in AWS Account ${AWS_ACCOUNT_ID}
                     ...    reproduce_hint=${c7n_output.cmd}
                     ...    details=Auto Scaling Group: ${asg_name}\n${human_friendly_key}: ${invalid_value}
-                    ...    next_steps=Validate Auto Scaling Group in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\`
+                    ...    next_steps=Escalate invalid Auto Scaling Group \`${asg_name}\` in AWS Region \`${AWS_REGION}\` in AWS account \`${AWS_ACCOUNT_ID}\` to service owner
                 END
             ELSE
                 Log    No invalid configurations found for ${asg_name}.
             END
         END
+    ELSE
+        RW.Core.Add Pre To Report    ${asg_list_length} invalid Auto Scaling Groups found, below threshold of ${MAX_ALLOWED_INVALID_ASG}\n${report_data.stdout}
     END
 
 ** Keywords ***

--- a/libraries/CloudCustodian/Core/Core.py
+++ b/libraries/CloudCustodian/Core/Core.py
@@ -41,6 +41,27 @@ def process_ec2_resource(resource, subdir_name, resource_summary):
         tags_str
     ])
 
+def process_asg_resource(resource, subdir_name, resource_summary):
+    asg_name = resource.get("AutoScalingGroupName", "Unknown ASG Name")
+    arn = resource.get("AutoScalingGroupARN", "Unknown ARN")
+    min_size = resource.get("MinSize", "Unknown Min Size")
+    max_size = resource.get("MaxSize", "Unknown Max Size")
+    desired_capacity = resource.get("DesiredCapacity", "Unknown Desired Capacity")
+    availability_zones = ", ".join(resource.get("AvailabilityZones", []))
+    tags = resource.get("Tags", [])
+    tags_str = ", ".join(f"{tag.get('Key', 'Unknown')}={tag.get('Value', 'Unknown')}" for tag in tags)
+
+    resource_summary.append([
+        subdir_name,
+        asg_name,
+        arn,
+        min_size,
+        max_size,
+        desired_capacity,
+        availability_zones,
+        tags_str
+    ])
+
 def parse_custodian_results(input_dir: str):
     """
     Parses Cloud Custodian results and summarizes resources, metadata, and run health.
@@ -79,6 +100,8 @@ def parse_custodian_results(input_dir: str):
                         resource_type = resource.get("c7n:resource-type", "Unknown")
                         if resource_type == "ec2" or resource.get("InstanceId"):
                             process_ec2_resource(resource, subdir_name, resource_summary)
+                        elif resource_type == "asg" or resource.get("AutoScalingGroupName"):
+                            process_asg_resource(resource, subdir_name, resource_summary)
                         else:
                             # Fallback for other resource types
                             resource_name = resource.get("Name", "Unknown Name")

--- a/libraries/CloudCustodian/Core/Core.py
+++ b/libraries/CloudCustodian/Core/Core.py
@@ -22,8 +22,24 @@ def parse_resource_type_from_arn(arn):
         print(f"Error parsing ARN: {e}")
     
     return "Unknown Type"
+def process_ec2_resource(resource, subdir_name, resource_summary):
+    instance_id = resource.get("InstanceId", "Unknown Instance ID")
+    instance_type = resource.get("InstanceType", "Unknown Instance Type")
+    state = resource.get("State", {}).get("Name", "Unknown State")
+    availability_zone = resource.get("Placement", {}).get("AvailabilityZone", "Unknown AZ")
+    private_ip = resource.get("PrivateIpAddress", "Unknown Private IP")
+    tags = resource.get("Tags", [])
+    tags_str = ", ".join(f"{tag.get('Key', 'Unknown')}={tag.get('Value', 'Unknown')}" for tag in tags)
 
-
+    resource_summary.append([
+        subdir_name,
+        instance_id,
+        instance_type,
+        state,
+        availability_zone,
+        private_ip,
+        tags_str
+    ])
 
 def parse_custodian_results(input_dir: str):
     """
@@ -45,105 +61,91 @@ def parse_custodian_results(input_dir: str):
     policy_summary = []
     log_summary = []
 
-    # Recursively traverse subdirectories
-    for subdir in input_path.iterdir():
-        if subdir.is_dir():
-            resources_file = subdir / "resources.json"
-            metadata_file = subdir / "metadata.json"
-            log_file = subdir / "custodian-run.log"
+    def process_files(resources_file, metadata_file, log_file, subdir_name):
+        # Parse resources.json
+        if resources_file.exists():
+            try:
+                with open(resources_file, "r") as f:
+                    resources = json.load(f)
+                    if not isinstance(resources, list):
+                        print(f"Skipping {resources_file}: Expected a list of resources.")
+                        return
 
-            # Parse resources.json
-            if resources_file.exists():
-                try:
-                    with open(resources_file, "r") as f:
-                        resources = json.load(f)
-                        if not isinstance(resources, list):
-                            print(f"Skipping {resources_file}: Expected a list of resources.")
+                    for resource in resources:
+                        if not isinstance(resource, dict):
+                            print(f"Skipping malformed resource in {resources_file}: {resource}")
                             continue
 
-                        for resource in resources:
-                            if not isinstance(resource, dict):
-                                print(f"Skipping malformed resource in {resources_file}: {resource}")
-                                continue
-
-                            # Resource attributes
+                        resource_type = resource.get("c7n:resource-type", "Unknown")
+                        if resource_type == "ec2" or resource.get("InstanceId"):
+                            process_ec2_resource(resource, subdir_name, resource_summary)
+                        else:
+                            # Fallback for other resource types
                             resource_name = resource.get("Name", "Unknown Name")
-
-                            # Extract the ARN
-                            policy_raw = resource.get("Policy", None)
-                            if isinstance(policy_raw, str):
-                                try:
-                                    policy = json.loads(policy_raw)
-                                    arn = policy.get("Statement", [])[0].get("Resource", "Unknown ARN")
-                                except json.JSONDecodeError:
-                                    arn = "Unknown ARN (Invalid Policy)"
-                            else:
-                                arn = "Unknown ARN"
-
-                            # Use the fixed ARN parsing function
-                            resource_type = parse_resource_type_from_arn(arn)
                             resource_location = resource.get("Location", {}).get("LocationConstraint", "Unknown Location")
-
-                            # Tags
-                            tags = resource.get("Tags", [])
-                            if isinstance(tags, list):
-                                tags_str = ", ".join(f"{tag.get('Key', 'Unknown')}={tag.get('Value', 'Unknown')}" for tag in tags)
-                            else:
-                                tags_str = "Unknown Tags"
-
-                            # Public Access Block
-                            public_access_block = resource.get("c7n:PublicAccessBlock", {})
-                            public_access = public_access_block.get("BlockPublicPolicy", "Unknown")
-
-                            # Append to resource summary
                             resource_summary.append([
-                                subdir.name,  # Policy name
+                                subdir_name,
                                 resource_name,
                                 resource_type,
                                 resource_location,
-                                tags_str,
-                                public_access
+                                "N/A",
+                                "N/A"
                             ])
-                except json.JSONDecodeError:
-                    print(f"Error reading resources.json in {subdir}: Invalid JSON format.")
-                except Exception as e:
-                    print(f"Error reading resources.json in {subdir}: {e}")
+            except json.JSONDecodeError:
+                print(f"Error reading resources.json in {subdir_name}: Invalid JSON format.")
+            except Exception as e:
+                print(f"Error reading resources.json in {subdir_name}: {e}")
 
+        # Parse metadata.json
+        if metadata_file.exists():
+            try:
+                with open(metadata_file, "r") as f:
+                    metadata = json.load(f)
+                    policy = metadata.get("policy", {})
+                    policy_name = policy.get("name", "Unknown Policy")
 
-                    
-            # Parse metadata.json
-            if metadata_file.exists():
-                try:
-                    with open(metadata_file, "r") as f:
-                        metadata = json.load(f)
-                        policy = metadata.get("policy", {})
-                        policy_name = policy.get("name", "Unknown Policy")
-                        
-                        # Extract metrics timestamps for start and end time
-                        metrics = metadata.get("metrics", [])
-                        if metrics:
-                            timestamps = [m.get("Timestamp") for m in metrics if m.get("Timestamp")]
-                            start_time = min(timestamps) if timestamps else "Unknown Start Time"
-                            end_time = max(timestamps) if timestamps else "Unknown End Time"
-                        else:
-                            start_time = "Unknown Start Time"
-                            end_time = "Unknown End Time"
+                    # Extract metrics timestamps for start and end time
+                    metrics = metadata.get("metrics", [])
+                    if metrics:
+                        timestamps = [m.get("Timestamp") for m in metrics if m.get("Timestamp")]
+                        start_time = min(timestamps) if timestamps else "Unknown Start Time"
+                        end_time = max(timestamps) if timestamps else "Unknown End Time"
+                    else:
+                        start_time = "Unknown Start Time"
+                        end_time = "Unknown End Time"
 
-                        # Add to policy summary
-                        policy_summary.append([policy_name, start_time, end_time])
-                except Exception as e:
-                    print(f"Error reading metadata.json in {subdir}: {e}")
+                    # Add to policy summary
+                    policy_summary.append([policy_name, start_time, end_time])
+            except Exception as e:
+                print(f"Error reading metadata.json in {subdir_name}: {e}")
 
-            # Parse custodian-run.log
-            if log_file.exists():
-                try:
-                    with open(log_file, "r") as f:
-                        logs = f.readlines()
-                        error_count = sum(1 for line in logs if "ERROR" in line)
-                        warning_count = sum(1 for line in logs if "WARNING" in line)
-                        log_summary.append([subdir.name, error_count, warning_count])
-                except Exception as e:
-                    print(f"Error reading custodian-run.log in {subdir}: {e}")
+        # Parse custodian-run.log
+        if log_file.exists():
+            try:
+                with open(log_file, "r") as f:
+                    logs = f.readlines()
+                    error_count = sum(1 for line in logs if "ERROR" in line)
+                    warning_count = sum(1 for line in logs if "WARNING" in line)
+                    log_summary.append([subdir_name, error_count, warning_count])
+            except Exception as e:
+                print(f"Error reading custodian-run.log in {subdir_name}: {e}")
+
+    # Check for subdirectories or direct files
+    subdirs = [d for d in input_path.iterdir() if d.is_dir()]
+    if not subdirs:
+        # No subdirectories, use current folder name as subdir
+        current_folder_name = input_path.name
+        resources_file = input_path / "resources.json"
+        metadata_file = input_path / "metadata.json"
+        log_file = input_path / "custodian-run.log"
+        process_files(resources_file, metadata_file, log_file, current_folder_name)
+    else:
+        # Process each subdirectory
+        for subdir in subdirs:
+            resources_file = subdir / "resources.json"
+            metadata_file = subdir / "metadata.json"
+            log_file = subdir / "custodian-run.log"
+            process_files(resources_file, metadata_file, log_file, subdir.name)
 
     # Generate combined summary
     results = []
@@ -151,7 +153,7 @@ def parse_custodian_results(input_dir: str):
     if resource_summary:
         results.append("Resource Summary:")
         results.append(tabulate(resource_summary, headers=[
-            "Policy Name", "Resource Name", "Resource Type", "Location", "Tags", "Public Access Blocked"
+            "Policy Name", "Resource ID", "Resource Type", "State", "Availability Zone", "Private IP", "Tags"
         ], tablefmt="grid"))
 
     if policy_summary:


### PR DESCRIPTION
This PR adds a couple of items that should be reviewed; 
- in cases where no issues were found, no report data would show up in the UI, looking like the task may not have completed successfully. It's important to always include report data, even if things look good. "Good" is just as important as anything that raises issues. 
- added some additional resource.json parsing structure to the `CloudCustodian.Core.Parse Custodian Results` keyword for specific resources that are used in this CodeBundle
- added some logic to pass a specific subdirectory (as the parsing was parsing all results in the folder, which was showing results from other tasks)
- identified an ASG test case where invalid_items was "True" and not the list of the invalid items specifically - added this and tested both the invalid ssh key (which produces a proper list/item), and deleted the launch template (which results in just "True") - tested both cases. 